### PR TITLE
Require Jenkins 2.346.3 or newer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+### Version 3.3 (Mar 17, 2014)
+
+-   Initial OSS release

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# CloudBees Credentials plugin
+
+This plugin extends [Credentials Plugin](https://plugins.jenkins.io/credentials/) and
+allow Jenkins to store your [CloudBees](http://www.cloudbees.com/)
+account information and its password. This is normally not a plugin that
+you'll choose to install on its own. Rather, it gets installed as a
+dependency of other plugins.
+
+## Version History
+
+[GitHub releases](https://github.com/jenkinsci/cloudbees-credentials-plugin/releases) for latest versions.
+
+[CHANGELOG](CHANGELOG.md) for historical versions.

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@ This plugin is used to manage credentials within Jenkins. This plugin is used by
   <licenses>
     <license>
       <name>MIT</name>
-      <url>http://www.opensource.org/licenses/mit-license.php</url>
+      <url>https://www.opensource.org/licenses/mit-license.php</url>
     </license>
   </licenses>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -40,13 +40,10 @@
   <packaging>hpi</packaging>
 
   <name>CloudBees Credentials Plugin</name>
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Credentials+Plugin</url>
-  <description>
-This plugin is used to manage credentials within Jenkins. This plugin is used by CloudBees plugins to access CloudBees services. 
-  </description>
+  <url>https://github.com/jenkinsci/cloudbees-credentials-plugin</url>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
+    <connection>scm:git:https://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <tag>HEAD</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@ This plugin is used to manage credentials within Jenkins. This plugin is used by
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <tag>HEAD</tag>
   </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,8 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.509</version>
+    <version>4.51</version>
+    <relativePath />
   </parent>
 
   <groupId>com.cloudbees.jenkins.plugins</groupId>
@@ -52,8 +53,20 @@ This plugin is used to manage credentials within Jenkins. This plugin is used by
   </scm>
 
   <properties>
-    <maven.findbugs.failure.strict>true</maven.findbugs.failure.strict>
+    <jenkins.version>2.346.3</jenkins.version>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.346.x</artifactId>
+        <version>1763.v092b_8980a_f5e</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <!-- regular dependencies -->
@@ -61,39 +74,15 @@ This plugin is used to manage credentials within Jenkins. This plugin is used by
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>1.3</version>
     </dependency>
     <!-- jenkins dependencies -->
     <!-- test dependencies -->
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.8.5</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>findbugs-maven-plugin</artifactId>
-        <version>2.4.0</version>
-        <configuration>
-          <excludeFilterFile>src/findbugs/excludesFilter.xml</excludeFilterFile>
-          <failOnError>${maven.findbugs.failure.strict}</failOnError>
-        </configuration>
-        <executions>
-          <execution>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
 
   <licenses>
     <license>

--- a/src/findbugs/excludesFilter.xml
+++ b/src/findbugs/excludesFilter.xml
@@ -1,5 +1,0 @@
-<FindBugsFilter>
-  <Match>
-    <Class name="~.*\.Messages"/>
-  </Match>
-</FindBugsFilter>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,5 @@
+<?jelly escape-by-default='true'?>
 <div>
   <b>CloudBees Credentials Plugin</b><br/>
-This plugin is used to manage credentials within Jenkins. This plugin is used by CloudBees plugins to access CloudBees services. 
+This plugin is used to manage credentials within Jenkins. This plugin is used by CloudBees plugins to access CloudBees services.
 </div>


### PR DESCRIPTION
## Require Jenkins 2.346.3 or newer

This plugin is installed on over 3400 Jenkins controllers worldwide.  It has an implied dependency on the deprecated WMI Windows Agents plugin as shown by https://plugins.jenkins.io/cloudbees-credentials/#dependencies .  Users that have installed this plugin cannot remove the WMI Windows Agents plugin without removing this plugin as well.  Rather than require that users remove this plugin, let's release a new version of the plugin that requires Jenkins 2.346.3 or newer.

See [JENKINS-70301](https://issues.jenkins.io/browse/JENKINS-70301) for a more detailed description of implied dependencies and why they are a complication for Jenkins users.

Changes include:

- Escape jelly pages by default
- Use https for SCM URL instead of http
- Use https for license URL
- Require Jenkins 2.346.3 or newer
- Remove unused findbugs exclusion file

Modernization simplifies in case someone needs to modify this in the future.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
